### PR TITLE
replace $keys array literal check

### DIFF
--- a/FileBag.php
+++ b/FileBag.php
@@ -92,7 +92,7 @@ class FileBag extends ParameterBag
             $keys = array_keys($file);
             sort($keys);
 
-            if ($keys == self::$fileKeys) {
+            if (array_intersect_key(self::$fileKeys, $keys) == self::$fileKeys) {
                 if (UPLOAD_ERR_NO_FILE == $file['error']) {
                     $file = null;
                 } else {


### PR DESCRIPTION
use array intersect to check if the required array keys exist, allowing more than what is present to exist without causing a fail